### PR TITLE
Improve ss encoder

### DIFF
--- a/app/src/main/java/jp/co/soramitsu/fearless_utils_android/MainActivity.kt
+++ b/app/src/main/java/jp/co/soramitsu/fearless_utils_android/MainActivity.kt
@@ -8,7 +8,6 @@ import jp.co.soramitsu.fearless_utils.encrypt.KeypairFactory
 import jp.co.soramitsu.fearless_utils.encrypt.Signer
 import jp.co.soramitsu.fearless_utils.encrypt.json.JsonSeedDecoder
 import jp.co.soramitsu.fearless_utils.encrypt.json.JsonSeedEncoder
-import jp.co.soramitsu.fearless_utils.ss58.SS58Encoder
 import org.spongycastle.util.encoders.Hex
 import java.security.SecureRandom
 
@@ -17,10 +16,10 @@ private val PASSWORD = "12345"
 private val NAME = "name"
 
 private const val ADDRESS_TYPE_WESTEND: Byte = 42
-private const val GENESIS_HASH_WESTEND = "e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e"
+private const val GENESIS_HASH_WESTEND =
+    "e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e"
 
 private val gson = Gson()
-private val ss58 = SS58Encoder()
 private val keypairFactory = KeypairFactory()
 
 class MainActivity : AppCompatActivity() {
@@ -36,13 +35,8 @@ class MainActivity : AppCompatActivity() {
     private fun shouldEncodeSr25519Json() {
         val keypairExpected = keypairFactory.generate(EncryptionType.SR25519, SEED)
 
-        val decoder = JsonSeedDecoder(
-            gson,
-            ss58,
-            keypairFactory
-        )
-
-        val encoder = JsonSeedEncoder(gson, ss58, SecureRandom())
+        val decoder = JsonSeedDecoder(gson, keypairFactory)
+        val encoder = JsonSeedEncoder(gson, SecureRandom())
 
         val json = encoder.generate(
             keypair = keypairExpected,

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/encrypt/json/JsonSeedEncoder.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/encrypt/json/JsonSeedEncoder.kt
@@ -6,7 +6,7 @@ import jp.co.soramitsu.fearless_utils.encrypt.Sr25519
 import jp.co.soramitsu.fearless_utils.encrypt.model.JsonAccountData
 import jp.co.soramitsu.fearless_utils.encrypt.model.Keypair
 import jp.co.soramitsu.fearless_utils.encrypt.xsalsa20poly1305.SecretBox
-import jp.co.soramitsu.fearless_utils.ss58.SS58Encoder
+import jp.co.soramitsu.fearless_utils.ss58.SS58Encoder.toAddress
 import org.spongycastle.crypto.generators.SCrypt
 import org.spongycastle.util.encoders.Base64
 import java.util.Random
@@ -19,7 +19,6 @@ private const val r = 8
 @Suppress("EXPERIMENTAL_API_USAGE")
 class JsonSeedEncoder(
     private val gson: Gson,
-    private val sS58Encoder: SS58Encoder,
     private val random: Random
 ) {
     fun generate(
@@ -32,7 +31,7 @@ class JsonSeedEncoder(
         addressByte: Byte
     ): String {
         val encoded = formEncodedField(keypair, seed, password, encryptionType)
-        val address = sS58Encoder.encode(keypair.publicKey, addressByte)
+        val address = keypair.publicKey.toAddress(addressByte)
 
         val importData = JsonAccountData(
             encoded = encoded,
@@ -69,7 +68,7 @@ class JsonSeedEncoder(
         val secret = secretBox.seal(nonce, pkcs8Bytes)
 
         val encodedBytes = salt + N.asLittleEndianBytes() + p.asLittleEndianBytes() +
-            r.asLittleEndianBytes() + nonce + secret
+                r.asLittleEndianBytes() + nonce + secret
 
         return Base64.toBase64String(encodedBytes)
     }

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/ss58/SS58Encoder.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/ss58/SS58Encoder.kt
@@ -5,6 +5,7 @@ import jp.co.soramitsu.fearless_utils.encrypt.json.copyBytes
 import jp.co.soramitsu.fearless_utils.exceptions.AddressFormatException
 import jp.co.soramitsu.fearless_utils.hash.Hasher.blake2b256
 import jp.co.soramitsu.fearless_utils.hash.Hasher.blake2b512
+import java.lang.Exception
 
 object SS58Encoder {
 
@@ -47,7 +48,7 @@ object SS58Encoder {
 
     fun extractAddressByteOrNull(address: String): Byte? = try {
         extractAddressByte(address)
-    } catch (e: AddressFormatException) {
+    } catch (e: Exception) {
         null
     }
 

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/ss58/SS58Encoder.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/ss58/SS58Encoder.kt
@@ -6,15 +6,12 @@ import jp.co.soramitsu.fearless_utils.exceptions.AddressFormatException
 import jp.co.soramitsu.fearless_utils.hash.Hasher.blake2b256
 import jp.co.soramitsu.fearless_utils.hash.Hasher.blake2b512
 
-class SS58Encoder {
+object SS58Encoder {
 
-    companion object {
-
-        private val PREFIX = "SS58PRE".toByteArray(Charsets.UTF_8)
-        private const val ADDRESS_TYPE_SIZE = 1
-        private const val PREFIX_SIZE = 2
-        private const val PUBLIC_KEY_SIZE = 32
-    }
+    private val PREFIX = "SS58PRE".toByteArray(Charsets.UTF_8)
+    private const val ADDRESS_TYPE_SIZE = 1
+    private const val PREFIX_SIZE = 2
+    private const val PUBLIC_KEY_SIZE = 32
 
     private val base58 = Base58()
 
@@ -53,4 +50,12 @@ class SS58Encoder {
     } catch (e: AddressFormatException) {
         null
     }
+
+    fun ByteArray.toAddress(addressByte: Byte) = encode(this, addressByte)
+
+    fun String.toAccountId() = decode(this)
+
+    fun String.addressByte() = extractAddressByte(this)
+
+    fun String.addressByteOrNull() = extractAddressByteOrNull(this)
 }

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/encrypt/JsonSeedDecoderTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/encrypt/JsonSeedDecoderTest.kt
@@ -49,14 +49,9 @@ private const val NOT_JSON = "not json"
 @RunWith(MockitoJUnitRunner::class)
 class JsonSeedDecoderTest {
     private val gson = Gson()
-    private val ss58 = SS58Encoder()
     private val keypairFactory = KeypairFactory()
 
-    private val decoder = JsonSeedDecoder(
-        gson,
-        ss58,
-        keypairFactory
-    )
+    private val decoder = JsonSeedDecoder(gson, keypairFactory)
 
     @Test
     fun `should decode valid json with correct password`() {

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/encrypt/JsonSeedEncoderTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/encrypt/JsonSeedEncoderTest.kt
@@ -20,16 +20,10 @@ private const val NAME = "test"
 @RunWith(MockitoJUnitRunner::class)
 class JsonSeedEncoderTest {
     private val gson = Gson()
-    private val ss58 = SS58Encoder()
     private val keypairFactory = KeypairFactory()
 
-    private val decoder = JsonSeedDecoder(
-        gson,
-        ss58,
-        keypairFactory
-    )
-
-    private val encoder = JsonSeedEncoder(gson, ss58, SecureRandom())
+    private val decoder = JsonSeedDecoder(gson, keypairFactory)
+    private val encoder = JsonSeedEncoder(gson, SecureRandom())
 
     @Test
     fun `should encode ed25519`() {

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/integration/account/AccountBalanceRequestTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/integration/account/AccountBalanceRequestTest.kt
@@ -3,6 +3,7 @@ package jp.co.soramitsu.fearless_utils.integration.account
 import jp.co.soramitsu.fearless_utils.integration.BaseIntegrationTest
 import jp.co.soramitsu.fearless_utils.integration.WESTEND_URL
 import jp.co.soramitsu.fearless_utils.ss58.SS58Encoder
+import jp.co.soramitsu.fearless_utils.ss58.SS58Encoder.toAccountId
 import jp.co.soramitsu.fearless_utils.wsrpc.executeAsync
 import jp.co.soramitsu.fearless_utils.wsrpc.request.runtime.account.AccountInfoRequest
 import kotlinx.coroutines.runBlocking
@@ -15,7 +16,6 @@ import org.mockito.junit.MockitoJUnitRunner
 @RunWith(MockitoJUnitRunner::class)
 @Ignore("Manual run only")
 class AccountBalanceRequestTest : BaseIntegrationTest(WESTEND_URL) {
-    private val encoder = SS58Encoder()
 
     @Test
     fun `should fetch null balance`() = runBlocking {
@@ -31,7 +31,7 @@ class AccountBalanceRequestTest : BaseIntegrationTest(WESTEND_URL) {
     fun `should fetch existing balance`() = runBlocking {
         val address = "5DEwU2U97RnBHCpfwHMDfJC7pqAdfWaPFib9wiZcr2ephSfT"
 
-        val publicKey = encoder.decode(address)
+        val publicKey = address.toAccountId()
 
         val response = socketService.executeAsync(AccountInfoRequest(publicKey))
 

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/ModulesTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/ModulesTest.kt
@@ -1,6 +1,6 @@
 package jp.co.soramitsu.fearless_utils.runtime
 
-import jp.co.soramitsu.fearless_utils.ss58.SS58Encoder
+import jp.co.soramitsu.fearless_utils.ss58.SS58Encoder.toAccountId
 import org.bouncycastle.util.encoders.Hex
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -11,14 +11,13 @@ private const val ADDRESS = "5CDayXd3cDCWpBkSXVsVfhE5bWKyTZdD3D1XUinR1ezS1sGn"
 
 @RunWith(MockitoJUnitRunner::class)
 class ModulesTest {
-    private val sS58Encoder = SS58Encoder()
 
     @Test
     fun `should create stacking-bonded key`() {
         val expected =
             "0x5f3e4907f716ac89b6347d15ececedca3ed14b45ed20d054f05e37e2542cfe70102af806668257c706c60aeddcff7ecdf122d0299e915f63815cdc06a5fbabaa639588b4b9283d50"
 
-        val bytes = sS58Encoder.decode(ADDRESS)
+        val bytes = ADDRESS.toAccountId()
 
         val key = Module.Staking.Bonded.storageKey(bytes)
 

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/ss58/SS58EncoderTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/ss58/SS58EncoderTest.kt
@@ -3,6 +3,8 @@ package jp.co.soramitsu.fearless_utils.ss58
 import jp.co.soramitsu.fearless_utils.common.TestAddressBytes
 import jp.co.soramitsu.fearless_utils.extensions.fromHex
 import jp.co.soramitsu.fearless_utils.extensions.toHexString
+import jp.co.soramitsu.fearless_utils.ss58.SS58Encoder.toAccountId
+import jp.co.soramitsu.fearless_utils.ss58.SS58Encoder.toAddress
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -15,23 +17,16 @@ class SS58EncoderTest {
     private val PUBLIC_KEY = "6addccf0b805e2d0dc445239b800201e1fb6f17f92ef4eaa1516f4d0e2cf1664"
     private val KUSAMA_ADDRESS = "EzSUv17LNHTU2xdPKLuLkPy7fCD795DZ6d5CnF4x4HSkcb4"
 
-    private lateinit var ss58Encoder: SS58Encoder
-
-    @Before
-    fun setUp() {
-        ss58Encoder = SS58Encoder()
-    }
-
     @Test
     fun `should encode address from public key`() {
-        val result = ss58Encoder.encode(PUBLIC_KEY.fromHex(), TestAddressBytes.KUSAMA)
+        val result = PUBLIC_KEY.fromHex().toAddress(TestAddressBytes.KUSAMA)
 
         assertEquals(KUSAMA_ADDRESS, result)
     }
 
     @Test
     fun `should decode public key from address`() {
-        val result = ss58Encoder.decode(KUSAMA_ADDRESS).toHexString()
+        val result = KUSAMA_ADDRESS.toAccountId().toHexString()
 
         assertEquals(PUBLIC_KEY, result)
     }


### PR DESCRIPTION
Make ss58 encoder to be object, since it has no state and just wraps several functions
Add extensions for the correspoing functions to make usage more consise
Catch all exceptions in addressByteOrNull, not only AddressFormatExeption