### PR TITLE
Fix storage key creating preconditions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         // App version
-        versionName = '1.0.0'
+        versionName = '1.0.55'
         versionCode = 1
 
         // SDK and tools

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadata.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadata.kt
@@ -121,6 +121,7 @@ class StorageEntry(
 sealed class StorageEntryType(
     val value: Type<*>?
 ) {
+
     companion object {
         fun from(typeRegistry: TypeRegistry, value: Any?) = when (value) {
             is String -> Plain(typeRegistry, value)


### PR DESCRIPTION
The current version of storageKey(..) checks whether the storage entry type matches with the number of arguments (Plain -> 0, Map -> 1, DoubleMap-> 2)

But it is possible to query Map and DoubleMap with less nubmer of arguments, in such a case the resulting key will be used as prefix and the result of query will be all keys in map with this prefix

Version was incremented because of publishing to MavenLocal. I think it is better from now to keep version in build.gradke consistent with the one in the Nexus