### PR TITLE
Thread safe blake2b

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         // App version
-        versionName = '1.0.70'
+        versionName = '1.0.71'
         versionCode = 1
 
         // SDK and tools

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/encrypt/Signer.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/encrypt/Signer.kt
@@ -1,7 +1,7 @@
 package jp.co.soramitsu.fearless_utils.encrypt
 
 import jp.co.soramitsu.fearless_utils.encrypt.model.Keypair
-import jp.co.soramitsu.fearless_utils.hash.Hasher
+import jp.co.soramitsu.fearless_utils.hash.Hasher.blake2b256
 import net.i2p.crypto.eddsa.EdDSAEngine
 import net.i2p.crypto.eddsa.EdDSAPrivateKey
 import net.i2p.crypto.eddsa.EdDSAPublicKey
@@ -44,7 +44,11 @@ object Signer {
         return SignatureWrapper.Other(signature = sign)
     }
 
-    fun verifySr25519(message: ByteArray, signature: ByteArray, publicKeyBytes: ByteArray): Boolean {
+    fun verifySr25519(
+        message: ByteArray,
+        signature: ByteArray,
+        publicKeyBytes: ByteArray
+    ): Boolean {
         return Sr25519.verify(signature, message, publicKeyBytes)
     }
 
@@ -84,7 +88,7 @@ object Signer {
         val privateKey = BigInteger(Hex.toHexString(keypair.privateKey), 16)
         val publicKey = Sign.publicKeyFromPrivate(privateKey)
 
-        val messageHash = Hasher.blake2b256.digest(message)
+        val messageHash = message.blake2b256()
 
         val sign = Sign.signMessage(messageHash, ECKeyPair(privateKey, publicKey), false)
 

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/hash/Hasher.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/hash/Hasher.kt
@@ -4,9 +4,13 @@ import net.jpountz.xxhash.XXHashFactory
 import org.bouncycastle.jcajce.provider.digest.Blake2b
 
 object Hasher {
-    val blake2b256 = Blake2b.Blake2b256()
-    val blake2b128 = Blake2b128()
-    val blake2b512 = Blake2b.Blake2b512()
+    private val blake2bLock = Any()
+
+    private val blake2b256 = Blake2b.Blake2b256()
+
+    private val blake2b128 = Blake2b128()
+
+    private val blake2b512 = Blake2b.Blake2b512()
 
     val xxHash64 = XXHashFactory.safeInstance().hash64()
     val xxHash128 = XXHash(128, xxHash64)
@@ -16,7 +20,11 @@ object Hasher {
     fun ByteArray.xxHash128() = xxHash128.hash(this)
     fun ByteArray.xxHash256() = xxHash256.hash(this)
 
-    fun ByteArray.blake2b128() = blake2b128.digest(this)
-    fun ByteArray.blake2b256() = blake2b256.digest(this)
-    fun ByteArray.blake2b512() = blake2b512.digest(this)
+    fun ByteArray.blake2b128() = withBlake2bLock { blake2b128.digest(this) }
+    fun ByteArray.blake2b256() = withBlake2bLock { blake2b256.digest(this) }
+    fun ByteArray.blake2b512() = withBlake2bLock { blake2b512.digest(this) }
+
+    fun ByteArray.blake2b128Concat() = withBlake2bLock { blake2b128.hashConcat(this) }
+
+    private inline fun <T> withBlake2bLock(action: () -> T) = synchronized(blake2bLock, action)
 }

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/StorageUtils.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/StorageUtils.kt
@@ -2,13 +2,14 @@ package jp.co.soramitsu.fearless_utils.runtime
 
 import jp.co.soramitsu.fearless_utils.extensions.toHexString
 import jp.co.soramitsu.fearless_utils.hash.Hasher
+import jp.co.soramitsu.fearless_utils.hash.Hasher.blake2b128Concat
 import jp.co.soramitsu.fearless_utils.hash.Hasher.xxHash128
 import jp.co.soramitsu.fearless_utils.hash.hashConcat
 
 typealias HashFunction = (ByteArray) -> ByteArray
 
 enum class IdentifierHasher(val hasher: HashFunction) {
-    Blake2b128concat(Hasher.blake2b128::hashConcat),
+    Blake2b128concat({ it.blake2b128Concat() }),
     TwoX64Concat(Hasher.xxHash64::hashConcat)
 }
 

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadataSchema.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/metadata/RuntimeMetadataSchema.kt
@@ -1,6 +1,9 @@
 package jp.co.soramitsu.fearless_utils.runtime.metadata
 
 import jp.co.soramitsu.fearless_utils.hash.Hasher
+import jp.co.soramitsu.fearless_utils.hash.Hasher.blake2b128
+import jp.co.soramitsu.fearless_utils.hash.Hasher.blake2b128Concat
+import jp.co.soramitsu.fearless_utils.hash.Hasher.blake2b256
 import jp.co.soramitsu.fearless_utils.hash.hashConcat
 import jp.co.soramitsu.fearless_utils.scale.EncodableStruct
 import jp.co.soramitsu.fearless_utils.scale.Schema
@@ -83,9 +86,9 @@ object DoubleMapSchema : Schema<DoubleMapSchema>() {
 }
 
 enum class StorageHasher(val hashingFunction: (ByteArray) -> ByteArray) {
-    Blake2_128(Hasher.blake2b128::digest),
-    Blake2_256(Hasher.blake2b256::digest),
-    Blake2_128Concat(Hasher.blake2b128::hashConcat),
+    Blake2_128({ it.blake2b128() }),
+    Blake2_256({ it.blake2b256() }),
+    Blake2_128Concat({ it.blake2b128Concat() }),
     Twox128(Hasher.xxHash128::hash),
     Twox256(Hasher.xxHash256::hash),
     Twox64Concat(Hasher.xxHash64::hashConcat),
@@ -136,8 +139,12 @@ object ExtrinsicMetadataSchema : Schema<ExtrinsicMetadataSchema>() {
     val signedExtensions by vector(stringType)
 }
 
-fun EncodableStruct<RuntimeMetadataSchema>.module(name: String) = get(RuntimeMetadataSchema.modules).find { it[ModuleMetadataSchema.name] == name }
+fun EncodableStruct<RuntimeMetadataSchema>.module(name: String) =
+    get(RuntimeMetadataSchema.modules).find { it[ModuleMetadataSchema.name] == name }
 
-fun EncodableStruct<ModuleMetadataSchema>.call(name: String) = get(ModuleMetadataSchema.calls)?.find { it[FunctionMetadataSchema.name] == name }
+fun EncodableStruct<ModuleMetadataSchema>.call(name: String) =
+    get(ModuleMetadataSchema.calls)?.find { it[FunctionMetadataSchema.name] == name }
 
-fun EncodableStruct<ModuleMetadataSchema>.storage(name: String) = get(ModuleMetadataSchema.storage)?.get(StorageMetadataSchema.entries)?.find { it[StorageEntryMetadataSchema.name] == name }
+fun EncodableStruct<ModuleMetadataSchema>.storage(name: String) =
+    get(ModuleMetadataSchema.storage)?.get(StorageMetadataSchema.entries)
+        ?.find { it[StorageEntryMetadataSchema.name] == name }

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/encrypt/JsonSeedDecoderTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/encrypt/JsonSeedDecoderTest.kt
@@ -133,7 +133,7 @@ class JsonSeedDecoderTest {
     }
 
     @Test
-    @Ignore("sr25519 is not supported in unit tests")
+//    @Ignore("sr25519 is not supported in unit tests")
     fun `should not extract seed from sr25519 crypto`() {
         val result = decoder.decode(VALID_JSON_SR25519, VALID_PASSWORD)
 

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/encrypt/JsonSeedDecoderTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/encrypt/JsonSeedDecoderTest.kt
@@ -133,7 +133,7 @@ class JsonSeedDecoderTest {
     }
 
     @Test
-//    @Ignore("sr25519 is not supported in unit tests")
+    @Ignore("sr25519 is not supported in unit tests")
     fun `should not extract seed from sr25519 crypto`() {
         val result = decoder.decode(VALID_JSON_SR25519, VALID_PASSWORD)
 

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/hash/HasherTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/hash/HasherTest.kt
@@ -1,0 +1,32 @@
+package jp.co.soramitsu.fearless_utils.hash
+
+import jp.co.soramitsu.fearless_utils.hash.Hasher.blake2b256
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import kotlin.random.Random
+
+class HasherTest {
+
+    @Test
+    fun `blake2b should be thread safe`(): Unit = runBlocking {
+        val testData = (0..1000).map { Random.nextBytes(32) }
+
+        val sequentialResults = testData.map { it.blake2b256() }
+
+        val concurrentResults = testData
+            .map {
+                // Lazy to ensure parallel start later for more concurrency
+                async(Dispatchers.Default, CoroutineStart.LAZY) { it.blake2b256() }
+            }.awaitAll()
+
+        assert(
+            sequentialResults
+                .zip(concurrentResults)
+                .all { (expected, actual) -> expected.contentEquals(actual) }
+        )
+    }
+}


### PR DESCRIPTION
Blake2b is turned to be not thread-safe, which caused several crashes in our production
To ensure correctness, a test for 1000 concurrent hashing was added. It stably crashes without fix, so we can assume it cheks thread-safety quite well.

Warning: may break backward compatibility if clients use directly blacke2bxxx instances instead of extensions