### PR TITLE
Enreach information stored in GenericCall

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         // App version
-        versionName = '1.0.71'
+        versionName = '1.0.72'
         versionCode = 1
 
         // SDK and tools

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/extrinsic/ExtrinsicBuilder.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/runtime/extrinsic/ExtrinsicBuilder.kt
@@ -44,7 +44,10 @@ class ExtrinsicBuilder(
         callIndex: Int,
         args: Map<String, Any?>
     ): ExtrinsicBuilder {
-        calls.add(GenericCall.Instance(moduleIndex, callIndex, args))
+        val module = runtime.metadata.module(moduleIndex)
+        val function = module.call(callIndex)
+
+        calls.add(GenericCall.Instance(module, function, args))
 
         return this
     }
@@ -54,10 +57,10 @@ class ExtrinsicBuilder(
         callName: String,
         arguments: Map<String, Any?>
     ): ExtrinsicBuilder {
-        val call = runtime.metadata.module(moduleName).call(callName)
-        val (moduleIndex, callIndex) = call.index
+        val module = runtime.metadata.module(moduleName)
+        val function = module.call(callName)
 
-        calls.add(GenericCall.Instance(moduleIndex, callIndex, arguments))
+        calls.add(GenericCall.Instance(module, function, arguments))
 
         return this
     }
@@ -119,12 +122,12 @@ class ExtrinsicBuilder(
     }
 
     private fun wrapInBatch(): GenericCall.Instance {
-        val batchCall = runtime.metadata.module("Utility").call("batch")
-        val (moduleIndex, callIndex) = batchCall.index
+        val batchModule = runtime.metadata.module("Utility")
+        val batchFunction = batchModule.call("batch")
 
         return GenericCall.Instance(
-            moduleIndex = moduleIndex,
-            callIndex = callIndex,
+            module = batchModule,
+            function = batchFunction,
             arguments = mapOf(
                 "calls" to calls
             )

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/BaseTypeTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/BaseTypeTest.kt
@@ -47,7 +47,7 @@ abstract class BaseTypeTest {
                                 )
                             ),
                             documentation = emptyList(),
-                            index = 0 to 0
+                            index = 1 to 0
                         )
                     ),
                     events = mapOf(
@@ -58,7 +58,7 @@ abstract class BaseTypeTest {
                                 u8
                             ),
                             documentation = emptyList(),
-                            index = 0 to 0
+                            index = 1 to 0
                         )
                     ),
                     constants = emptyMap(),

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/generics/ExtrinsicTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/generics/ExtrinsicTest.kt
@@ -7,6 +7,8 @@ import jp.co.soramitsu.fearless_utils.runtime.RealRuntimeProvider
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.composite.DictEnum
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.fromHex
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.toHex
+import jp.co.soramitsu.fearless_utils.runtime.metadata.call
+import jp.co.soramitsu.fearless_utils.runtime.metadata.module
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.math.BigInteger
@@ -33,16 +35,18 @@ class ExtrinsicTest {
 
         val decoded = Extrinsic.fromHex(runtime, batch)
 
-        assertEquals(16, decoded.call.moduleIndex)
-        assertEquals(0, decoded.call.callIndex)
+        assertEquals(16 to 0, decoded.call.function.index)
         assertEquals(2, (decoded.call.arguments["calls"] as List<*>).size)
     }
 
     @Test
     fun `should encode transfer extrinsic`() {
+        val module = runtime.metadata.module("Balances")
+        val function = module.call("transfer_keep_alive")
+
         val call = GenericCall.Instance(
-            moduleIndex = 4,
-            callIndex = 3,
+            module,
+            function,
             arguments = mapOf(
                 "dest" to DictEnum.Entry(
                     name = "Id",

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/generics/GenericCallTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/generics/GenericCallTest.kt
@@ -5,6 +5,8 @@ import jp.co.soramitsu.fearless_utils.runtime.definitions.types.BaseTypeTest
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.errors.EncodeDecodeException
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.fromHex
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.toHex
+import jp.co.soramitsu.fearless_utils.runtime.metadata.call
+import jp.co.soramitsu.fearless_utils.runtime.metadata.module
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -14,9 +16,12 @@ class GenericCallTest : BaseTypeTest() {
 
     val inHex = "0x01000103"
 
+    val module = runtime.metadata.module("A")
+    val function = module.call("B")
+
     val instance = GenericCall.Instance(
-        moduleIndex = 1,
-        callIndex = 0,
+        module = module,
+        function = function,
         arguments = mapOf(
             "arg1" to true,
             "arg2" to 3.toBigInteger()
@@ -35,26 +40,15 @@ class GenericCallTest : BaseTypeTest() {
         val decoded = GenericCall.fromHex(runtime, inHex)
 
         assertEquals(instance.arguments, decoded.arguments)
-        assertEquals(instance.moduleIndex, decoded.moduleIndex)
-        assertEquals(instance.callIndex, decoded.callIndex)
-    }
-
-    @Test
-    fun `should throw for encoding instance with invalid index`() {
-        val invalidInstance = GenericCall.Instance(
-            moduleIndex = 2,
-            callIndex = 3,
-            arguments = emptyMap()
-        )
-
-        assertThrows<EncodeDecodeException> { GenericCall.toHex(runtime, invalidInstance) }
+        assertEquals(instance.module, decoded.module)
+        assertEquals(instance.function, decoded.function)
     }
 
     @Test
     fun `should throw for encoding instance with invalid arguments`() {
         val invalidInstance = GenericCall.Instance(
-            moduleIndex = 1,
-            callIndex = 0,
+            module,
+            function,
             arguments = mapOf(
                 "arg1" to true,
                 "arg2" to 3  // invalid param type - should be BigInteger

--- a/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/generics/OpaqueCallTest.kt
+++ b/fearless-utils/src/test/java/jp/co/soramitsu/fearless_utils/runtime/definitions/types/generics/OpaqueCallTest.kt
@@ -3,15 +3,20 @@ package jp.co.soramitsu.fearless_utils.runtime.definitions.types.generics
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.BaseTypeTest
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.fromHex
 import jp.co.soramitsu.fearless_utils.runtime.definitions.types.toHex
+import jp.co.soramitsu.fearless_utils.runtime.metadata.call
+import jp.co.soramitsu.fearless_utils.runtime.metadata.module
 import org.junit.Assert.*
 import org.junit.Test
 
 class OpaqueCallTest : BaseTypeTest() {
     val inHex = "0x1001000103"
 
+    val module = runtime.metadata.module("A")
+    val function = module.call("B")
+
     val instance = GenericCall.Instance(
-        moduleIndex = 1,
-        callIndex = 0,
+        module = module,
+        function = function,
         arguments = mapOf(
             "arg1" to true,
             "arg2" to 3.toBigInteger()
@@ -23,8 +28,7 @@ class OpaqueCallTest : BaseTypeTest() {
         val decoded = OpaqueCall.fromHex(runtime, inHex)
 
         assertEquals(instance.arguments, decoded.arguments)
-        assertEquals(instance.moduleIndex, decoded.moduleIndex)
-        assertEquals(instance.callIndex, decoded.callIndex)
+        assertEquals(instance.function, decoded.function)
     }
 
     @Test


### PR DESCRIPTION
It was not very comfortable to use GenericCall info to determine call metadata (module, function) by indices. This PR resolves this issue by replacing indices with Module and Function instances, providing all possible information (names, docs, arg types) to the client code.