### PR TITLE
Make mnemonic creator public

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         // App version
-        versionName = '1.0.80'
+        versionName = '1.0.81'
         versionCode = 1
 
         // SDK and tools

--- a/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/encrypt/mnemonic/MnemonicCreator.kt
+++ b/fearless-utils/src/main/java/jp/co/soramitsu/fearless_utils/encrypt/mnemonic/MnemonicCreator.kt
@@ -13,7 +13,7 @@ import kotlin.math.floor
 private val DELIMITER_REGEX = "[\\s,]+".toRegex()
 private val SPACE = EnglishWordList.INSTANCE.space.toString()
 
-internal object MnemonicCreator {
+object MnemonicCreator {
 
     fun randomMnemonic(length: Mnemonic.Length): Mnemonic = SecureCharBuffer().use { secure ->
         val entropy = ByteArray(length.byteLength)


### PR DESCRIPTION
In Fearless Android we have a use case when it is required to generate mnemonic without deriving seed (which requires a password from derivation path)
Currently, it is not possible to use the public API of the library.
Solution - include MnemonicCreator to public API. 