### PR TITLE
chore: align sr25519 outputs to 16kb

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,23 @@
+[target.aarch64-linux-android]
+rustflags = [
+    "-C", "link-arg=-Wl,-z,common-page-size=4096",
+    "-C", "link-arg=-Wl,-z,max-page-size=16384",
+]
+
+[target.armv7-linux-androideabi]
+rustflags = [
+    "-C", "link-arg=-Wl,-z,common-page-size=4096",
+    "-C", "link-arg=-Wl,-z,max-page-size=16384",
+]
+
+[target.x86_64-linux-android]
+rustflags = [
+    "-C", "link-arg=-Wl,-z,common-page-size=4096",
+    "-C", "link-arg=-Wl,-z,max-page-size=16384",
+]
+
+[target.i686-linux-android]
+rustflags = [
+    "-C", "link-arg=-Wl,-z,common-page-size=4096",
+    "-C", "link-arg=-Wl,-z,max-page-size=16384",
+]

--- a/fearless-utils/build.gradle
+++ b/fearless-utils/build.gradle
@@ -34,8 +34,7 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    ndkVersion "25.2.9519653"
-    //ndkVersion "22.1.7171670"
+    ndkVersion "28.0.12674087"
 
     sourceSets {
         test {

--- a/fearless-utils/build.gradle
+++ b/fearless-utils/build.gradle
@@ -55,6 +55,7 @@ cargo {
     module = "../sr25519-java/"
     libname = "sr25519java"
     targets = ["arm", "arm64", "x86", "x86_64"]
+    profile = "release"
 }
 
 tasks.whenTaskAdded { task ->


### PR DESCRIPTION
- settings.gradle:32 now auto-detects a local fearless-utils-Android checkout (or honors FEARLESS_UTILS_PATH) so the app always builds against the repo sources; set USE_REMOTE_UTILS=true only when you explicitly want Gradle to fetch the GitHub repo.
- app/build.gradle:24-35,195 restricts supported ABIs, ensures our vendored libsr25519java.so/libsodium.so win any merge conflicts, and documents the native packaging expectations.
- scripts/build-libsodium.sh + third_party/libsodium/** let you regenerate aligned libsodium binaries on demand; README.md:85 and AGENTS.md:74 explain how to point the build to local utils and refresh the vendored natives.
- app/src/main/jniLibs/**/libsr25519java.so and libsodium.so now contain the release-profile builds produced from the repo sources (16 KB-aligned, verified via llvm-readelf -l … | grep LOAD).